### PR TITLE
docs(readme): add TS syntax highlighting into code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,18 @@
 
 ### With Yarn
 
-```
+```bash
 yarn add use-selected-items-hook
 ```
 
 ### With NPM
-```
+```bash
 npm install use-selected-items-hook
 ```
 
 # :pushpin: Usage
 
-```
+```typescript
 import useSelectedItems from "use-selected-items-hook";
 
    const [
@@ -97,7 +97,7 @@ order to compare the items.
 # :computer: API
 
 ## useSelectedItem
-```
+```typescript
    export type Item<T> = T & {
       selected: boolean
    };


### PR DESCRIPTION
> Just a brief update to turn code snippets of TypeScript prettier about syntax highlighting.

**Before**
```
export type Item<T> = T & {
      selected: boolean
   };

   export interface Actions<T> {
      toggleItem: (T) => void,
      setSelectedItems: Dispatch<SetStateAction<T[]>>,
      setItemsList: Dispatch<SetStateAction<Item<T>[]>>
   }

   useSelectedItems<T>({
      itemIdentifier: string | number,
      items: T[],
   }): [T[], Item<T>[], Actions<T>];
```

**After**
```typescript
export type Item<T> = T & {
      selected: boolean
   };

   export interface Actions<T> {
      toggleItem: (T) => void,
      setSelectedItems: Dispatch<SetStateAction<T[]>>,
      setItemsList: Dispatch<SetStateAction<Item<T>[]>>
   }

   useSelectedItems<T>({
      itemIdentifier: string | number,
      items: T[],
   }): [T[], Item<T>[], Actions<T>];
```