### PR TITLE
refactor: do not return selected items within isSelected state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,15 +85,24 @@ function useSelectedItems<T extends DefaultItem, K extends string>({
     itemIdentifierKey,
   ]);
 
+  const selectedItems = useMemo(() => (
+    items
+      .filter(item => item.isSelected)
+      .map(({ isSelected: _isSelected, ...rest }) => ({
+        ...rest,
+      })) as T[]
+  ), [items]);
+
   const payload = useMemo<HookReturnValues<T>>(
     () => ({
       items,
-      selectedItems: items.filter(item => item.isSelected),
+      selectedItems,
       toggleAllItems,
       toggleSingleItem,
     }),
     [
       items,
+      selectedItems,
       toggleAllItems,
       toggleSingleItem,
     ],

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ export interface State<T = DefaultItem, K = DefaultItemIdentifierKey> {
 
 export interface HookReturnValues<T> {
   items: Item<T>[];
-  selectedItems: Item<T>[];
+  selectedItems: T[];
   toggleAllItems: () => void;
   toggleSingleItem: (itemIdentifierValue: any) => void;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
Remove `isSelected` state property from being returned within `selectedItems` array

#### Testing instructions:
1. Select an item by executing `toggleSingleItem` with a valid identifier value
2. `console.log` the `selectedItems` array in order to verify if the `isSelected` property is being returned within the items


#### Proposed changelog entry for your changes:
Selected Items: Do not return `selectedItems`  within ` isSelected` state property 