### PR TITLE
perf: improve type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,12 @@ npm install use-selected-items-hook
 import useSelectedItems from "use-selected-items-hook";
 import classNames from "classNames";
 
-interface ExampleItem {
-   id: number;
-   text: string;
-}
 
 const initialExampleItems = [
    { id: 1, text: "What's up" }
 ];
+
+type ExampleItem = typeof initialExampleItems[number]
 
 const Example: React.FC = () => {
   const [exampleItems, setExampleItems] = useState(initialExampleItems);
@@ -105,24 +103,6 @@ As shown in the example above, you're able to pass an array of items from any ty
 order to compare the items.
 
 # :computer: API
-
-## Types Definitions
-```typescript
-export interface Arguments<T = DefaultItem, K = DefaultItemIdentifierKey> {
-  initialItems: T[];
-  itemIdentifierKey: K;
-  initialSelectedItems?: T[];
-}
-
-export interface HookReturnValues<T> {
-  items: Item<T>[];
-  selectedItems: Item<T>[];
-  toggleAllItems: () => void;
-  toggleSingleItem: (itemIdentifierValue: any) => void;
-}
-```
-
----
 
 ## Initialization
 To initialize the `items` array, the `initialItems` must be passed as an argument. It's also possible to initialize the items already with an `isSelected` state, but to do so, it's necessary to provide the `initialSelectedItems` argument.

--- a/README.md
+++ b/README.md
@@ -44,63 +44,7 @@ yarn add use-selected-items-hook
 npm install use-selected-items-hook
 ```
 
-# :pushpin: Usage
-
-```tsx
-import useSelectedItems from "use-selected-items-hook";
-import classNames from "classNames";
-
-
-const initialExampleItems = [
-   { id: 1, text: "What's up" }
-];
-
-type ExampleItem = typeof initialExampleItems[number]
-
-const Example: React.FC = () => {
-  const [exampleItems, setExampleItems] = useState(initialExampleItems);
-
-  const {
-    items,
-    selectedItems,
-    toggleAllItems,
-    toggleSingleItem,
-  } = useSelectedItems<ExampleItem, ExampleItem["text"]>({
-    itemIdentifierKey: "id",
-    initialItems: exampleItems,
-  });
-
-   const handleClick = (itemId) => () => {
-      toggleSingleItem(itemId);
-   };
-
-   return (
-      <div>
-         {
-            items.map(item => {
-               // Applying classes according to the isSelected status 
-               const itemClasses = classNames("relative cursor-pointer rounded-lg border-4 border-white border-solid", {
-                  "border-indigo-500": item.isSelected,
-               });
-
-                return (
-                  <button
-                    key={item.id}
-                    className={itemClasses}
-                    onClick={handleClick(item.id)}
-                  >
-                     {item.text}
-                  </button>
-                );
-            })
-         }
-      </div>
-   )
-};
-```
-
-As shown in the example above, you're able to pass an array of items from any type of source, as long it has a unique identifier in
-order to compare the items.
+# :pushpin: [Usage](./example/pages/index.tsx) 
 
 # :computer: API
 

--- a/example/components/TravelsModal/types.ts
+++ b/example/components/TravelsModal/types.ts
@@ -2,7 +2,7 @@ import { Item } from "use-selected-items-hook/dist/types";
 
 import { Travel } from "../../shared/types";
 
-export interface TravelsModalProps {
+export type TravelsModalProps = {
   isModalOpen: boolean;
   selectedTravels: Item<Travel>[];
   handleCloseModal: () => void;

--- a/example/components/ui/types.ts
+++ b/example/components/ui/types.ts
@@ -1,3 +1,3 @@
-export interface AspectRatioProps {
+export type AspectRatioProps = {
   ratio: number;
 }

--- a/example/pages/index.tsx
+++ b/example/pages/index.tsx
@@ -25,7 +25,7 @@ const Main: React.FC = () => {
     selectedItems,
     toggleAllItems,
     toggleSingleItem,
-  } = useSelectedItems<Travel, string>({
+  } = useSelectedItems<Travel>({
     itemIdentifierKey: "id",
     initialItems: travelsItems,
   });
@@ -42,7 +42,7 @@ const Main: React.FC = () => {
   }, [fetchTravels]);
 
   const handleClick = (item) => () => {
-    toggleSingleItem(item.id);
+    toggleSingleItem(item);
   };
 
   const handleOpenModal = useCallback(() => {

--- a/example/shared/types.ts
+++ b/example/shared/types.ts
@@ -1,4 +1,4 @@
-export interface Travel {
+export type Travel = {
   id: number;
   name: string;
   imageUrl: string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,0 @@
-import { State } from "./types";
-
-export const INITIAL_STATE: State = {
-  items: [],
-  itemIdentifierKey: null,
-};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,36 +1,24 @@
 import {
-  Reducer,
   useMemo,
   useEffect,
   useReducer,
   useCallback,
 } from "react";
 
+import { Arguments, ActionType, DefaultItem } from "./types";
 import reducer from "./reducer";
-import {
-  State,
-  Action,
-  Arguments,
-  ActionType,
-  DefaultItem,
-} from "./types";
 
-function useSelectedItems<Item extends DefaultItem, ItemIdentifierKey extends string>({
+function useSelectedItems<Item extends DefaultItem>({
   initialItems = [],
   itemIdentifierKey,
   initialSelectedItems = [],
-}: Arguments<Item, ItemIdentifierKey>) {
-  const [{ items }, dispatch] = useReducer<
-    Reducer<State<
-      Item, ItemIdentifierKey>,
-      Action<Item, ItemIdentifierKey>
-    >
-  >(
-    reducer<Item, ItemIdentifierKey>(),
+}: Arguments<Item>) {
+  const [{ items }, dispatch] = useReducer(
+    reducer<Item>(),
     { items: [], itemIdentifierKey },
   );
 
-  const toggleSingleItem = useCallback((itemIdentifierValue: Item[ItemIdentifierKey]) => {
+  const toggleSingleItem = useCallback((itemIdentifierValue: Item[typeof itemIdentifierKey]) => {
     dispatch({
       type: ActionType.TOGGLE_SINGLE_ITEM,
       payload: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  Reducer,
   useMemo,
   useEffect,
   useReducer,
@@ -8,28 +9,31 @@ import {
 import reducer from "./reducer";
 import {
   State,
+  Action,
   Arguments,
   ActionType,
   DefaultItem,
-  HookReturnValues,
 } from "./types";
 import { INITIAL_STATE } from "./constants";
 
-function useSelectedItems<T extends DefaultItem, K extends string>({
+function useSelectedItems<Item extends DefaultItem, ItemIdentifierKey extends string>({
   initialItems = [],
   itemIdentifierKey,
   initialSelectedItems = [],
-}: Arguments<T, K>) {
-  const [{ items }, dispatch] = useReducer(
-    reducer,
+}: Arguments<Item, ItemIdentifierKey>) {
+  const [{ items }, dispatch] = useReducer<
+    Reducer<State<Item, ItemIdentifierKey>, Action<Item, ItemIdentifierKey>>,
+    State<Item, ItemIdentifierKey>
+  >(
+    reducer<Item, ItemIdentifierKey>(),
     INITIAL_STATE,
-    (state: State) => ({
+    (state: State<Item, ItemIdentifierKey>) => ({
       ...state,
       itemIdentifierKey,
     }),
   );
 
-  const toggleSingleItem = useCallback((itemIdentifierValue: T) => {
+  const toggleSingleItem = useCallback((itemIdentifierValue: Item[ItemIdentifierKey]) => {
     dispatch({
       type: ActionType.TOGGLE_SINGLE_ITEM,
       payload: {
@@ -90,10 +94,10 @@ function useSelectedItems<T extends DefaultItem, K extends string>({
       .filter(item => item.isSelected)
       .map(({ isSelected: _isSelected, ...rest }) => ({
         ...rest,
-      })) as T[]
+      }))
   ), [items]);
 
-  const payload = useMemo<HookReturnValues<T>>(
+  const payload = useMemo(
     () => ({
       items,
       selectedItems,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,14 +18,14 @@ function useSelectedItems<Item extends DefaultItem>({
     { items: [], itemIdentifierKey },
   );
 
-  const toggleSingleItem = useCallback((itemIdentifierValue: Item[typeof itemIdentifierKey]) => {
+  const toggleSingleItem = useCallback((item: Item) => {
     dispatch({
       type: ActionType.TOGGLE_SINGLE_ITEM,
       payload: {
-        itemIdentifierValue,
+        itemIdentifierValue: item[itemIdentifierKey],
       },
     });
-  }, []);
+  }, [itemIdentifierKey]);
 
   const toggleAllItems = useCallback(() => {
     dispatch({

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ import {
   ActionType,
   DefaultItem,
 } from "./types";
-import { INITIAL_STATE } from "./constants";
 
 function useSelectedItems<Item extends DefaultItem, ItemIdentifierKey extends string>({
   initialItems = [],
@@ -22,15 +21,13 @@ function useSelectedItems<Item extends DefaultItem, ItemIdentifierKey extends st
   initialSelectedItems = [],
 }: Arguments<Item, ItemIdentifierKey>) {
   const [{ items }, dispatch] = useReducer<
-    Reducer<State<Item, ItemIdentifierKey>, Action<Item, ItemIdentifierKey>>,
-    State<Item, ItemIdentifierKey>
+    Reducer<State<
+      Item, ItemIdentifierKey>,
+      Action<Item, ItemIdentifierKey>
+    >
   >(
     reducer<Item, ItemIdentifierKey>(),
-    INITIAL_STATE,
-    (state: State<Item, ItemIdentifierKey>) => ({
-      ...state,
-      itemIdentifierKey,
-    }),
+    { items: [], itemIdentifierKey },
   );
 
   const toggleSingleItem = useCallback((itemIdentifierValue: Item[ItemIdentifierKey]) => {

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -30,7 +30,7 @@ const reducer: <Item, ItemIdentifier extends string>() => Reducer<
       const { itemIdentifierValue } = action.payload;
 
       const itemIndex = items.findIndex((itemFound) => (
-        itemFound[itemIdentifierKey] === itemIdentifierValue
+        itemFound[itemIdentifierKey as string] === itemIdentifierValue
       ));
 
       const item = items[itemIndex];

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -3,10 +3,7 @@ import update from "immutability-helper";
 
 import { State, Action, ActionType } from "./types";
 
-const reducer: <Item, ItemIdentifier extends string>() => Reducer<
-  State<Item, ItemIdentifier>,
-  Action<Item, ItemIdentifier>
-> = () => (state, action) => {
+const reducer: <Item>() => Reducer<State<Item>, Action<Item>> = () => (state, action) => {
   switch (action.type) {
     case ActionType.INITIALIZE_ITEMS: {
       const {

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -3,7 +3,10 @@ import update from "immutability-helper";
 
 import { State, Action, ActionType } from "./types";
 
-const reducer: Reducer<State, Action> = (state, action) => {
+const reducer: <Item, ItemIdentifier extends string>() => Reducer<
+  State<Item, ItemIdentifier>,
+  Action<Item, ItemIdentifier>
+> = () => (state, action) => {
   switch (action.type) {
     case ActionType.INITIALIZE_ITEMS: {
       const {

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -30,7 +30,7 @@ const reducer: <Item, ItemIdentifier extends string>() => Reducer<
       const { itemIdentifierValue } = action.payload;
 
       const itemIndex = items.findIndex((itemFound) => (
-        itemFound[itemIdentifierKey as string] === itemIdentifierValue
+        itemFound[itemIdentifierKey] === itemIdentifierValue
       ));
 
       const item = items[itemIndex];

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,42 +2,37 @@ export type DefaultItem = Record<any, any>;
 
 export type DefaultItemIdentifierKey = any;
 
-export interface Arguments<T = DefaultItem, K = DefaultItemIdentifierKey> {
-  initialItems: T[];
-  itemIdentifierKey: K;
-  initialSelectedItems?: T[];
-}
-
-export type Item<T> = T & {
+export type ItemWithSelectedState<T> = T & {
   isSelected: boolean;
+  [key: string]: any;
 }
 
-export interface State<T = DefaultItem, K = DefaultItemIdentifierKey> {
-  items: Item<T>[];
-  itemIdentifierKey: K;
+export type Arguments<Item, ItemIdentifierKey extends string> = {
+  initialItems: Array<Item>;
+  itemIdentifierKey: ItemIdentifierKey;
+  initialSelectedItems?: Array<Item>;
 }
 
-export interface HookReturnValues<T> {
-  items: Item<T>[];
-  selectedItems: T[];
-  toggleAllItems: () => void;
-  toggleSingleItem: (itemIdentifierValue: any) => void;
+export type State<Item, IdentifierKey extends string> = {
+  items: Array<ItemWithSelectedState<Item>>;
+  itemIdentifierKey: IdentifierKey;
 }
 
-export enum ActionType {
-  INITIALIZE_ITEMS,
-  TOGGLE_ALL_ITEMS,
-  TOGGLE_SINGLE_ITEM,
-}
+export const ActionType = {
+  INITIALIZE_ITEMS: "INITIALIZE_ITEMS",
+  TOGGLE_ALL_ITEMS: "TOGGLE_ALL_ITEMS",
+  TOGGLE_SINGLE_ITEM: "TOGGLE_SINGLE_ITEM",
+} as const;
 
-interface ActionPayloads extends Record<ActionType, any> {
+type ActionPayloads<Item extends DefaultItem, ItemIdentifierKey extends string> = {
   [ActionType.TOGGLE_SINGLE_ITEM]: {
-    itemIdentifierValue?: any;
+    itemIdentifierValue?: Item[ItemIdentifierKey];
   };
   [ActionType.INITIALIZE_ITEMS]: {
-    initialSelectedItems: Item<any>[];
-    initialItems: Item<any>[];
+    initialSelectedItems: Array<Item>;
+    initialItems: Array<Item>;
   };
+  [ActionType.TOGGLE_ALL_ITEMS]: undefined;
 }
 
 type ActionMap<M extends Record<string, any>> = {
@@ -51,4 +46,8 @@ type ActionMap<M extends Record<string, any>> = {
       }
 };
 
-export type Action = ActionMap<ActionPayloads>[keyof ActionMap<ActionPayloads>]
+export type Action<Item, ItemIdentifierKey extends string> = (
+  ActionMap<ActionPayloads<Item, ItemIdentifierKey>>[
+    keyof ActionMap<ActionPayloads<Item, ItemIdentifierKey>>
+  ]
+)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 export type DefaultItem = Record<any, any>;
 
-export type ItemIdentifierKey = string | number;
+export type ItemIdentifierKey<Item> = keyof Item;
 
 export type ItemWithSelectedState<T> = T & {
   isSelected: boolean;
@@ -9,13 +9,13 @@ export type ItemWithSelectedState<T> = T & {
 
 export type Arguments<Item> = {
   initialItems: Array<Item>;
-  itemIdentifierKey: ItemIdentifierKey;
+  itemIdentifierKey: ItemIdentifierKey<Item>;
   initialSelectedItems?: Array<Item>;
 }
 
 export type State<Item> = {
   items: Array<ItemWithSelectedState<Item>>;
-  itemIdentifierKey: ItemIdentifierKey;
+  itemIdentifierKey: ItemIdentifierKey<Item>;
 }
 
 export const ActionType = {
@@ -26,7 +26,7 @@ export const ActionType = {
 
 type ActionPayloads<Item extends DefaultItem> = {
   [ActionType.TOGGLE_SINGLE_ITEM]: {
-    itemIdentifierValue?: Item[ItemIdentifierKey];
+    itemIdentifierValue?: Item[ItemIdentifierKey<Item>];
   };
   [ActionType.INITIALIZE_ITEMS]: {
     initialSelectedItems: Array<Item>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,21 +1,21 @@
 export type DefaultItem = Record<any, any>;
 
-export type DefaultItemIdentifierKey = any;
+export type ItemIdentifierKey = string | number;
 
 export type ItemWithSelectedState<T> = T & {
   isSelected: boolean;
   [key: string]: any;
 }
 
-export type Arguments<Item, ItemIdentifierKey extends string> = {
+export type Arguments<Item> = {
   initialItems: Array<Item>;
   itemIdentifierKey: ItemIdentifierKey;
   initialSelectedItems?: Array<Item>;
 }
 
-export type State<Item, IdentifierKey extends string> = {
+export type State<Item> = {
   items: Array<ItemWithSelectedState<Item>>;
-  itemIdentifierKey: IdentifierKey;
+  itemIdentifierKey: ItemIdentifierKey;
 }
 
 export const ActionType = {
@@ -24,7 +24,7 @@ export const ActionType = {
   TOGGLE_SINGLE_ITEM: "TOGGLE_SINGLE_ITEM",
 } as const;
 
-type ActionPayloads<Item extends DefaultItem, ItemIdentifierKey extends string> = {
+type ActionPayloads<Item extends DefaultItem> = {
   [ActionType.TOGGLE_SINGLE_ITEM]: {
     itemIdentifierValue?: Item[ItemIdentifierKey];
   };
@@ -46,8 +46,6 @@ type ActionMap<M extends Record<string, any>> = {
       }
 };
 
-export type Action<Item, ItemIdentifierKey extends string> = (
-  ActionMap<ActionPayloads<Item, ItemIdentifierKey>>[
-    keyof ActionMap<ActionPayloads<Item, ItemIdentifierKey>>
-  ]
+export type Action<Item> = (
+  ActionMap<ActionPayloads<Item>>[keyof ActionMap<ActionPayloads<Item>>]
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
- Use literal types instead of interfaces - Refer to the benefits in this [article](https://pawelgrzybek.com/typescript-interface-vs-type/)
- Improve nomenclature of generic types - Refer to this [article](https://fettblog.eu/tidy-typescript-name-your-generics/)
- Use `keyof` operator to access the item identifier key type - Refer to this [article](https://mariusschulz.com/blog/keyof-and-lookup-types-in-typescript)

